### PR TITLE
set Dockerfile ENV DEBIAN_FRONTEND=noninteractive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ LABEL repository="https://github.com/mgenteluci/cloudformation-deploy-action"
 LABEL homepage="https://github.com/mgenteluci/cloudformation-deploy-action"
 LABEL maintainer="Matheus Genteluci <mgenteluci97@gmail.com>"
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && apt-get install -y awscli
 
 ADD entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
This is needed for Ubuntu image to avoid asking to configure tzdata.
More info: https://askubuntu.com/questions/909277/avoiding-user-interaction-with-tzdata-when-installing-certbot-in-a-docker-contai